### PR TITLE
Updated NetBSD link

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,7 +175,7 @@ for people in Hawaii. This mirror (as of 2013) has the largest total hard drive 
 <a href="./pub/FreeBSD/">pub/FreeBSD</a> - Raw directory contents
 
 <h3 id="NetBSD"><img src="img/netbsd-logo.png" height="40" width="40"> NetBSD</h3>
-<a href="./pub/NetBSD/">pub/NetBSD</a> - Raw directory contents
+<a href="./pub/NetBSD/images/">pub/NetBSD/images</a> - Raw directory contents
 
 <h3 id="libreoffice"><img src="img/libreoffice-logo.png" height="40" width="40"> LibreOffice</h3>
 <a href="./pub/tdf/libreoffice/">pub/tdf/libreoffice</a> - Raw directory contents


### PR DESCRIPTION
Updating the NetBSD link in index.html to go straight to the /pub/NetBSD/images/ directory. The base directory took too long to properly mirror so the scripts were updated to only rsync the /images/ directory. 
